### PR TITLE
Add warnings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 Reexport = "0.2, 1"
-julia = "1.6"
 TimeZones = "1.17"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDates"
 uuid = "20186a3f-b5d3-468e-823e-77aae96fe2d8"
 authors = ["Daniel Rizk & Contributors"]
-version = "0.2.4"
+version = "0.2.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pkg.add(url = "https://github.com/TidierOrg/TidierDates.jl.git")
 
 #### `mdy()`, `dmy()`, `ymd()`
 
-These functions parse dates represented as strings into a DateTime format in Julia. The input should be a string month-day-year, day-month-year, or year-month-day format respectively. They are relatively robust in their ability to take non-uniform strings of dates. 
+These functions parse dates represented as strings into a DateTime format in Julia. The input should be a string month-day-year, day-month-year, or year-month-day format respectively. They are relatively robust in their ability to take non-uniform strings of dates. English, Spanish and French month names are supported.
 
 ```julia
 using TidierData

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pkg.add(url = "https://github.com/TidierOrg/TidierDates.jl.git")
 
 #### `mdy()`, `dmy()`, `ymd()`
 
-These functions parse dates represented as strings into a DateTime format in Julia. The input should be a string month-day-year, day-month-year, or year-month-day format respectively. They are relatively robust in their ability to take non-uniform strings of dates. English, Spanish and French month names are supported.
+These functions parse dates represented as strings into a DateTime format in Julia. The input should be a string month-day-year, day-month-year, or year-month-day format respectively. They are relatively robust in their ability to take non-uniform strings of dates. English, Spanish, Portuguese, and French months and abbreviations are supported.
 
 ```julia
 using TidierData

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,4 +19,4 @@ In addition, this package includes:
 - `leap_year()`
 - `days_in_month()`
 
-English, Spanish and French month names are supported.
+English, Spanish, Portuguese and French months and abbreviations are supported.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,3 +18,5 @@ In addition, this package includes:
 - `am()`, `pm()`
 - `leap_year()`
 - `days_in_month()`
+
+English, Spanish and French month names are supported.

--- a/src/TidierDates.jl
+++ b/src/TidierDates.jl
@@ -8,7 +8,7 @@ include("datedocstrings.jl")
 
 export mdy, mdy_hms, dmy, dmy_hms, ymd, ymd_hms, ymd_h, ymd_hm, 
 hms, difftime, floor_date, round_date, now, today, am, pm, leap_year, 
-days_in_month, dmy_h, dmy_hm, mdy_h, mdy_hm
+days_in_month, dmy_h, dmy_hm, mdy_h, mdy_hm, hm
 
 #### Create dictionaries to map full and abbreviated month names to numbers
 full_month_to_num = Dict{String, Int}(
@@ -70,7 +70,7 @@ end
 """
 $docstring_floor_date
 """
-function floor_date(dt::Union{DateTime, Missing}, unit::String)
+function floor_date(dt::Union{DateTime, Date, Time, Missing}, unit::String)
     if ismissing(dt)
         return missing
     end
@@ -80,8 +80,13 @@ function floor_date(dt::Union{DateTime, Missing}, unit::String)
     elseif unit == "month"
         return floor(dt, Month)
     elseif unit == "week"
-        start_of_week = firstdayofweek(dt) - Day(1)
-        return floor(start_of_week, Day)
+        if dayofweek(dt) != 7
+            start_of_week = floor(dt, Week)
+            start_of_week -= Day(1)
+            return start_of_week
+        else
+            return dt
+        end
     elseif unit == "day"
         return floor(dt, Day)
     elseif unit == "hour"
@@ -241,6 +246,21 @@ function days_in_month(dt::TimeType)::Int
     end
 
     return daysinmonth(dt)
+end
+
+
+"""
+$docstring_hm
+"""
+function hm(time_string::Union{AbstractString, Missing})
+    if ismissing(time_string)
+        return missing
+    end
+    try
+        return Time(time_string, "HH:MM")
+    catch
+       return missing
+    end
 end
 
 end

--- a/src/TidierDates.jl
+++ b/src/TidierDates.jl
@@ -14,13 +14,30 @@ days_in_month, dmy_h, dmy_hm, mdy_h, mdy_hm, hm
 full_month_to_num = Dict{String, Int}(
     "JANUARY" => 1, "FEBUARY" => 2, "MARCH" => 3, "APRIL" => 4,
     "MAY" => 5, "JUNE" => 6, "JULY" => 7, "AUGUST" => 8,
-    "SEPTEMBER" => 9, "OCTOBER" => 10, "NOVEMBER" => 11, "DECEMBER" => 12
+    "SEPTEMBER" => 9, "OCTOBER" => 10, "NOVEMBER" => 11, "DECEMBER" => 12, 
+    #spanish
+    "ENERO" => 1, "FEBRERO" => 2, "MARZO" => 3, "ABRIL" => 4,
+    "MAYO" => 5, "JUNIO" => 6, "JULIO" => 7, "AGOSTO" => 8,
+    "SEPTIEMBRE" => 9, "OCTUBRE" => 10, "NOVIEMBRE" => 11, "DICIEMBRE" => 12,
+    #french
+    "JANVIER" => 1, "FÉVRIER" => 2, "MARS" => 3, "AVRIL" => 4,
+    "MAI" => 5, "JUIN" => 6, "JUILLET" => 7, "AOÛT" => 8,
+    "SEPTEMBRE" => 9, "OCTOBRE" => 10, "NOVEMBRE" => 11, "DÉCEMBRE" => 12
 )
 
 abbreviated_month_to_num = Dict{String, Int}(
     "JAN" => 1, "FEB" => 2, "MAR" => 3, "APR" => 4,
     "MAY" => 5, "JUN" => 6, "JUL" => 7, "AUG" => 8,
-    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DEC" => 12
+    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DEC" => 12,
+    #spanish
+    "ENE" => 1, "FEB" => 2, "MAR" => 3, "ABR" => 4,
+    "MAY" => 5, "JUN" => 6, "JUL" => 7, "AGO" => 8,
+    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DIC" => 12,
+    #french
+    "JAN" => 1, "FÉV" => 2, "MAR" => 3, "AVR" => 4,
+    "MAI" => 5, "JUI" => 6, "JUIL" => 7, "AOÛ" => 8,
+    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DÉC" => 12
+
 )
 
 function replace_month_with_number(datetime_string::String)

--- a/src/TidierDates.jl
+++ b/src/TidierDates.jl
@@ -1,46 +1,19 @@
 module TidierDates
 
 using Dates, Reexport, TimeZones
+#Unicode
 
 @reexport using Dates
 
 include("datedocstrings.jl")
-
+include("month_dicts.jl")
 export mdy, mdy_hms, dmy, dmy_hms, ymd, ymd_hms, ymd_h, ymd_hm, 
 hms, difftime, floor_date, round_date, now, today, am, pm, leap_year, 
 days_in_month, dmy_h, dmy_hm, mdy_h, mdy_hm, hm
 
-#### Create dictionaries to map full and abbreviated month names to numbers
-full_month_to_num = Dict{String, Int}(
-    "JANUARY" => 1, "FEBUARY" => 2, "MARCH" => 3, "APRIL" => 4,
-    "MAY" => 5, "JUNE" => 6, "JULY" => 7, "AUGUST" => 8,
-    "SEPTEMBER" => 9, "OCTOBER" => 10, "NOVEMBER" => 11, "DECEMBER" => 12, 
-    #spanish
-    "ENERO" => 1, "FEBRERO" => 2, "MARZO" => 3, "ABRIL" => 4,
-    "MAYO" => 5, "JUNIO" => 6, "JULIO" => 7, "AGOSTO" => 8,
-    "SEPTIEMBRE" => 9, "OCTUBRE" => 10, "NOVIEMBRE" => 11, "DICIEMBRE" => 12,
-    #french
-    "JANVIER" => 1, "FÉVRIER" => 2, "MARS" => 3, "AVRIL" => 4,
-    "MAI" => 5, "JUIN" => 6, "JUILLET" => 7, "AOÛT" => 8,
-    "SEPTEMBRE" => 9, "OCTOBRE" => 10, "NOVEMBRE" => 11, "DÉCEMBRE" => 12
-)
 
-abbreviated_month_to_num = Dict{String, Int}(
-    "JAN" => 1, "FEB" => 2, "MAR" => 3, "APR" => 4,
-    "MAY" => 5, "JUN" => 6, "JUL" => 7, "AUG" => 8,
-    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DEC" => 12,
-    #spanish
-    "ENE" => 1, "FEB" => 2, "MAR" => 3, "ABR" => 4,
-    "MAY" => 5, "JUN" => 6, "JUL" => 7, "AGO" => 8,
-    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DIC" => 12,
-    #french
-    "JAN" => 1, "FÉV" => 2, "MAR" => 3, "AVR" => 4,
-    "MAI" => 5, "JUI" => 6, "JUIL" => 7, "AOÛ" => 8,
-    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DÉC" => 12
+function replace_month_with_number(datetime_string::Union{String, SubString{String}})
 
-)
-
-function replace_month_with_number(datetime_string::String)
     # Replace full month names
     for (month, num) in full_month_to_num
         datetime_string = replace(datetime_string, month => string(num))

--- a/src/datedocstrings.jl
+++ b/src/datedocstrings.jl
@@ -29,6 +29,9 @@ julia> mdy("01 24 2023")
 
 julia> mdy(missing)
 missing
+
+julia> mdy("FÉVRIER 20 2020")
+2020-02-20
 ```
 """
 
@@ -63,6 +66,9 @@ julia> dmy("3rd of December, 2020")
 
 julia> dmy(missing)
 missing
+
+julia> dmy("20 DICIEMBRE 2020")
+2020-12-20
 ```
 """
 

--- a/src/datedocstrings.jl
+++ b/src/datedocstrings.jl
@@ -30,7 +30,7 @@ julia> mdy("01 24 2023")
 julia> mdy(missing)
 missing
 
-julia> mdy("FÉVRIER 20 2020")
+julia> mdy("FÉVRIER 20 2020") # French
 2020-02-20
 ```
 """
@@ -67,8 +67,12 @@ julia> dmy("3rd of December, 2020")
 julia> dmy(missing)
 missing
 
-julia> dmy("20 DICIEMBRE 2020")
+julia> dmy("20 DICIEMBRE 2020") # Spanish
 2020-12-20
+
+julia> dmy("21 MARÇO 2014") # Portuguese 
+2014-03-21
+
 ```
 """
 

--- a/src/datedocstrings.jl
+++ b/src/datedocstrings.jl
@@ -131,7 +131,7 @@ Round down a DateTime object to the nearest specified unit.
 # Returns
 The DateTime object rounded down to the nearest specified unit. If the input is missing, the function returns a missing value.
 
-When using the "week" unit, Sunday is considered the first day of the week.
+When using the "week" unit, Sunday is considered the first day of the week, and if the date is already a Sunday, it is returned as is.
 
 # Examples
 ```jldoctest
@@ -401,7 +401,6 @@ false
 julia> leap_year(2020)
 true
 ```
-
 """
 
 const docstring_days_in_month =
@@ -579,7 +578,8 @@ A DateTime object constructed from the parsed month, day, year, and hour values 
 julia> mdy_hm("06-15-2023 09:03 P")
 2023-06-15T21:03:00
 
-julia> mdy_hm("06-15-2023 09:03 p")
+julia> mdy_hm("june 15 2023 09:03 p")
+2023-06-15T21:03:00
 
 julia> mdy_hm("06-15-2023 09:03 ")
 2023-06-15T09:03:00
@@ -589,4 +589,27 @@ julia> mdy_hm("june 15 2023 09:03 p")
 
 julia> mdy_hm(missing)
 missing
+```
+"""
+
+const docstring_hm =
+"""
+    hm(time_string::Union{AbstractString, Missing})::Time
+
+Converts a time string in the format "HH:MM" to a Time object.
+
+# Arguments
+`time_string`: A string containing a time representation. 
+
+# Returns
+A Time object constructed from the parsed hour and minute values from the input string, if all can be parsed successfully. Returns a missing value if the input is missing or if the time information cannot be parsed from the string.
+
+# Examples
+```jldoctest
+julia> hm("09:30")
+09:30:00
+
+julia> hm("12:60")
+missing
+```
 """

--- a/src/dmys.jl
+++ b/src/dmys.jl
@@ -145,10 +145,20 @@ function dmy_hm(datetime_string::Union{AbstractString, Missing})
         month = parse(Int, month_str)
         year = parse(Int, year_str)
         hour = parse(Int, hour_str)
-        if hour <= 12 && occursin(r"(?<![A-Za-z])[Pp](?:[Mm])?(?![A-Za-z])", datetime_string) 
+        minute = parse(Int, minute_str)
+        if minute == 60
+            @warn "Minute is 60, returning missing"
+            return missing
+        end
+        # Handle AM/PM format
+        if hour <= 12 && occursin(r"(?<![A-Za-z])[Pp](?:[Mm])?(?![A-Za-z])", datetime_string)
             hour += 12
         end
-        minute = parse(Int, minute_str)
+
+        # Handle the case when hour is 24 by incrementing the date and setting time to 00:xx
+        if hour == 24
+            return DateTime(year, month, day, 0, minute) + Day(1)
+        end
 
         # Return as DateTime
         return DateTime(year, month, day, hour, minute)
@@ -157,3 +167,4 @@ function dmy_hm(datetime_string::Union{AbstractString, Missing})
     # If no match found, return missing
     return missing
 end
+

--- a/src/dmys.jl
+++ b/src/dmys.jl
@@ -10,52 +10,61 @@ function dmy(date_string::Union{AbstractString, Missing})
         date_string = strip(replace(date_string, r"ST|ND|RD|TH|,|OF|THE" => ""))
         date_string = replace(date_string, r"\s+" => Base.s" ")
     end
-    
-    # Match for "ddmmyyyy" format
-    m = match(r"(\d{1,2})(\d{1,2})(\d{4})", date_string)
+
+    # Match for "ddmmyyyy" or "ddmmyy" format
+    m = match(r"^(\d{1,2})(\d{1,2})(\d{2,4})$", date_string)
     if m !== nothing
         day_str, month_str, year_str = m.captures
         day = parse(Int, day_str)
         month = parse(Int, month_str)
         year = parse(Int, year_str)
-        return Date(year, month, day)
-    end
-
-    # Match for "dd Month yyyy" format
-    m = match(r"(\d{1,2}) (\d{1,2}) (\d{4})", date_string)
-    if m !== nothing
-        day_str, month_str, year_str = m.captures
-        day = parse(Int, day_str)
-        month = parse(Int, month_str)
-        year = parse(Int, year_str)
-        return Date(year, month, day)
-    end
-
-    # Match for "Month dd, yyyy" format
-    m = match(r"(\d{1,2})(ST|ND|RD|TH)?\s*(\w+)\s*(\d{4})", date_string)
-    if m !== nothing
-        day_str, _, month_str, year_str = m.captures
-        day = parse(Int, day_str)
-        year = parse(Int, year_str)
-        month = tryparse(Int, month_str)
-        if month === nothing
-            return missing
+        if length(year_str) == 2
+            if year > 30
+                year += 1900
+            else
+            year += 2000
+            end
         end
         return Date(year, month, day)
     end
 
-    # Match for "dd-mm-yyyy" or "dd/mm/yyyy" format
-    m = match(r"(\d{1,2})[/-](\d{1,2})[/-](\d{4})", date_string)
+    # Match for "dd mm yyyy" or "dd mm yy" format
+    m = match(r"^(\d{1,2}) (\d{1,2}) (\d{2,4})$", date_string)
     if m !== nothing
         day_str, month_str, year_str = m.captures
         day = parse(Int, day_str)
         month = parse(Int, month_str)
         year = parse(Int, year_str)
+        if length(year_str) == 2
+            if year > 30
+                year += 1900
+            else
+            year += 2000
+            end
+        end
+        return Date(year, month, day)
+    end
+
+    # Match for "dd-mm-yyyy", "dd/mm/yyyy", "dd-mm-yy", or "dd/mm/yy" format
+    m = match(r"^(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})$", date_string)
+    if m !== nothing
+        day_str, month_str, year_str = m.captures
+        day = parse(Int, day_str)
+        month = parse(Int, month_str)
+        year = parse(Int, year_str)
+        if length(year_str) == 2
+            if year > 30
+                year += 1900
+            else
+            year += 2000
+            end
+        end
         return Date(year, month, day)
     end
 
     return missing
 end
+
 
 
 """

--- a/src/mdys.jl
+++ b/src/mdys.jl
@@ -2,6 +2,7 @@
 $docstring_mdy
 """
 function mdy(date_string::Union{AbstractString, Missing})
+
     if ismissing(date_string)
         return missing
     else
@@ -10,6 +11,7 @@ function mdy(date_string::Union{AbstractString, Missing})
         date_string = strip(replace(date_string, r"THE|ST|ND|RD|TH|,|OF |THE" => ""))
         date_string = replace(date_string, r"\s+" => Base.s" ")
     end
+    
 
     # Add new regex match for "m d yy" or "mm dd yyyy" format
     m = match(r"(\d{1,2})\s+(\d{1,2})\s+(\d{2,4})", date_string)

--- a/src/mdys.jl
+++ b/src/mdys.jl
@@ -10,26 +10,40 @@ function mdy(date_string::Union{AbstractString, Missing})
         date_string = strip(replace(date_string, r"THE|ST|ND|RD|TH|,|OF |THE" => ""))
         date_string = replace(date_string, r"\s+" => Base.s" ")
     end
-        # Add new regex match for "mmddyyyy" format
-        m = match(r"(\d{1,2})(\d{1,2})(\d{4})", date_string)
-        if m !== nothing
-            month_str, day_str, year_str = m.captures
-            month = parse(Int, month_str)
-            day = parse(Int, day_str)
-            year = parse(Int, year_str)
-            return Date(year, month, day)
-        end
 
-    m = match(r"(\w+)\s*(\d{1,2})(st|nd|rd|th)?,?\s*(\d{4})", date_string)
+    # Add new regex match for "m d yy" or "mm dd yyyy" format
+    m = match(r"(\d{1,2})\s+(\d{1,2})\s+(\d{2,4})", date_string)
     if m !== nothing
-        month_str, day_str, _, year_str = m.captures
-        month =  parse(Int, month_str)
+        month_str, day_str, year_str = m.captures
+        month = parse(Int, month_str)
+        day = parse(Int, day_str)
+        if length(year_str) == 2
+            year = parse(Int, "20" * year_str)  # Assuming 21st century
+        else
+            year = parse(Int, year_str)
+        end
+        return Date(year, month, day)
+    end
+
+    # Existing regex patterns
+    m = match(r"(\d{1,2})(\d{1,2})(\d{4})", date_string)
+    if m !== nothing
+        month_str, day_str, year_str = m.captures
+        month = parse(Int, month_str)
         day = parse(Int, day_str)
         year = parse(Int, year_str)
         return Date(year, month, day)
     end
 
-    # Add new regex match for "m/d/y" and "m-d-y" formats
+    m = match(r"(\w+)\s*(\d{1,2})(st|nd|rd|th)?,?\s*(\d{4})", date_string)
+    if m !== nothing
+        month_str, day_str, _, year_str = m.captures
+        month = parse(Int, month_str)
+        day = parse(Int, day_str)
+        year = parse(Int, year_str)
+        return Date(year, month, day)
+    end
+
     m = match(r"(\d{1,2})[/-](\d{1,2})[/-](\d{4})", date_string)
     if m !== nothing
         month_str, day_str, year_str = m.captures
@@ -39,8 +53,21 @@ function mdy(date_string::Union{AbstractString, Missing})
         return Date(year, month, day)
     end
 
+    m = match(r"(\d{1,2})[/-](\d{1,2})[/-](\d{2})", date_string)
+    if m !== nothing
+        month_str, day_str, year_str = m.captures
+        month = parse(Int, month_str)
+        day = parse(Int, day_str)
+        year = parse(Int, "20" * year_str)  # Assuming 21st century for two-digit years
+        return Date(year, month, day)
+    end
+
     return nothing
 end
+
+
+
+
 
 """
 $docstring_mdy_hms

--- a/src/mdys.jl
+++ b/src/mdys.jl
@@ -97,10 +97,21 @@ function mdy_hm(datetime_string::Union{AbstractString, Missing})
         month = parse(Int, month_str)
         day = parse(Int, day_str)
         hour = parse(Int, hour_str)
+        minute = parse(Int, minute_str)
+        
+        if minute == 60
+            @warn "Minute is 60, returning missing"
+            return missing
+        end
+        # Handle AM/PM format
         if hour <= 12 && occursin(r"(?<![A-Za-z])[Pp](?:[Mm])?(?![A-Za-z])", datetime_string)
             hour += 12
         end
-        minute = parse(Int, minute_str)
+        
+        # Handle the case when hour is 24 by incrementing the date and setting time to 00:xx
+        if hour == 24
+            return DateTime(year, month, day, 0, minute) + Day(1)
+        end
 
         # Return as DateTime
         return DateTime(year, month, day, hour, minute)
@@ -109,6 +120,7 @@ function mdy_hm(datetime_string::Union{AbstractString, Missing})
     # If no match found, return missing
     return missing
 end
+
 
 
 """

--- a/src/month_dicts.jl
+++ b/src/month_dicts.jl
@@ -1,0 +1,34 @@
+#### Create dictionaries to map full and abbreviated month names to numbers
+full_month_to_num = Dict{String, Int}(
+    "JANUARY" => 1, "FEBUARY" => 2, "MARCH" => 3, "APRIL" => 4,
+    "MAY" => 5, "JUNE" => 6, "JULY" => 7, "AUGUST" => 8,
+    "SEPTEMBER" => 9, "OCTOBER" => 10, "NOVEMBER" => 11, "DECEMBER" => 12, 
+    #spanish
+    "ENERO" => 1, "FEBRERO" => 2, "MARZO" => 3, "ABRIL" => 4,
+    "MAYO" => 5, "JUNIO" => 6, "JULIO" => 7, "AGOSTO" => 8,
+    "SEPTIEMBRE" => 9, "OCTUBRE" => 10, "NOVIEMBRE" => 11, "DICIEMBRE" => 12,
+    #french
+    "JANVIER" => 1, "FEVRIER" => 2, "FÉVRIER" => 2, "MARS" => 3, "AVRIL" => 4,
+    "MAI" => 5, "JUIN" => 6, "JUILLET" => 7, "AOÛT" => 8, "AOUT" => 8,
+    "SEPTEMBRE" => 9, "OCTOBRE" => 10, "NOVEMBRE" => 11, "DÉCEMBRE" => 12, "DECEMBRE" => 12,
+    #portugues
+    "JANEIRO" => 1, "FEVEREIRO" => 2, "MARÇO" => 3, "ABRIL" => 4,
+    "MAIO" => 5, "JUNHO" => 6, "JULHO" => 7, "AGOSTO" => 8,
+    "SETEMBRO" => 9, "OUTUBRO" => 10, "NOVEMBRO" => 11, "DEZEMBRO" => 12
+
+)
+
+abbreviated_month_to_num = Dict{String, Int}(
+    "JAN" => 1, "FEB" => 2, "MAR" => 3, "APR" => 4,
+    "MAY" => 5, "JUN" => 6, "JUL" => 7, "AUG" => 8,
+    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DEC" => 12,
+    #spanish
+    "ENE" => 1, "FEB" => 2, "MAR" => 3, "ABR" => 4,
+    "MAY" => 5, "JUN" => 6, "JUL" => 7, "AGO" => 8,
+    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DIC" => 12,
+    #french
+    "JAN" => 1, "FÉV" => 2, "MAR" => 3, "AVR" => 4,
+    "MAI" => 5, "JUI" => 6, "JUIL" => 7, "AOÛ" => 8, "AOU" => 8,
+    "SEP" => 9, "OCT" => 10, "NOV" => 11, "DÉC" => 12,
+    #portugues
+)

--- a/src/ymds.jl
+++ b/src/ymds.jl
@@ -98,10 +98,20 @@ function ymd_hm(datetime_string::Union{AbstractString, Missing})
         month = parse(Int, month_str)
         day = parse(Int, day_str)
         hour = parse(Int, hour_str)
+        minute = parse(Int, minute_str)
+        if minute == 60
+            @warn "Minute is 60, returning missing"
+            return missing
+        end
+        # Handle AM/PM format
         if hour <= 12 && occursin(r"(?<![A-Za-z])[Pp](?:[Mm])?(?![A-Za-z])", datetime_string)
             hour += 12
         end
-        minute = parse(Int, minute_str)
+
+        # Handle the case when hour is 24 by incrementing the date and setting the time to 00:xx
+        if hour == 24
+            return DateTime(year, month, day, 0, minute) + Day(1)
+        end
 
         # Return as DateTime
         return DateTime(year, month, day, hour, minute)
@@ -110,6 +120,7 @@ function ymd_hm(datetime_string::Union{AbstractString, Missing})
     # If no match found, return missing
     return missing
 end
+
 
 """
 $docstring_ymd_h

--- a/src/ymds.jl
+++ b/src/ymds.jl
@@ -2,6 +2,7 @@
 $docstring_ymd
 """
 function ymd(date_string::Union{AbstractString, Missing})
+
     if ismissing(date_string)
         return missing
     else

--- a/src/ymds.jl
+++ b/src/ymds.jl
@@ -10,31 +10,73 @@ function ymd(date_string::Union{AbstractString, Missing})
         date_string = strip(replace(date_string, r"ST|ND|RD|TH|,|OF|THE" => ""))
         date_string = replace(date_string, r"\s+" => Base.s" ")
     end
-    # Try "yyyymmdd" format
-    m = match(r"(\d{4})(\d{1,2})(\d{1,2})", date_string)
+
+    # Try "yyyymmdd" or "yymmdd" format
+    m = match(r"^(\d{2,4})(\d{1,2})(\d{1,2})$", date_string)
     if m !== nothing
         year_str, month_str, day_str = m.captures
         year = parse(Int, year_str)
+        if length(year_str) == 2
+            if year > 30
+                year += 1900
+            else
+            year += 2000
+            end
+        end
         month = parse(Int, month_str)
         day = parse(Int, day_str)
         return Date(year, month, day)
     end
 
-    # Try "yyyy/mm/dd" and "yyyy-mm-dd" formats
-    m = match(r"(\d{4})[/-](\d{1,2})[/-](\d{1,2})", date_string)
+    # Try "yyyy/mm/dd", "yyyy-mm-dd", "yy/mm/dd", or "yy-mm-dd" formats
+    m = match(r"^(\d{2,4})[/-](\d{1,2})[/-](\d{1,2})$", date_string)
     if m !== nothing
         year_str, month_str, day_str = m.captures
         year = parse(Int, year_str)
+        if length(year_str) == 2
+            if year > 30
+                year += 1900
+            else
+            year += 2000
+            end
+        end
         month = parse(Int, month_str)
         day = parse(Int, day_str)
         return Date(year, month, day)
     end
 
-        # Try "Year Month Day" format
-    m = match(r"(\d{4})\s*(\w+)\s*(\d{1,2})(st|nd|rd|th)?", date_string)
+    # Try "Year Month Day" format (month can be a number or word)
+    m = match(r"^(\d{2,4})\s+(\w+)\s+(\d{1,2})(st|nd|rd|th)?$", date_string)
     if m !== nothing
         year_str, month_str, day_str, _ = m.captures
         year = parse(Int, year_str)
+        if length(year_str) == 2
+            if year > 30
+                year += 1900
+            else
+            year += 2000
+            end
+        end
+        month = tryparse(Int, month_str)
+        if month === nothing
+            month = parse(Int, replace_month_with_number(month_str))
+        end
+        day = parse(Int, day_str)
+        return Date(year, month, day)
+    end
+
+    # Try "yyyy mm dd" or "yy mm dd" format
+    m = match(r"^(\d{2,4})\s+(\d{1,2})\s+(\d{1,2})$", date_string)
+    if m !== nothing
+        year_str, month_str, day_str = m.captures
+        year = parse(Int, year_str)
+        if length(year_str) == 2
+            if year > 30
+                year += 1900
+            else
+            year += 2000
+            end
+        end
         month = parse(Int, month_str)
         day = parse(Int, day_str)
         return Date(year, month, day)
@@ -42,6 +84,7 @@ function ymd(date_string::Union{AbstractString, Missing})
 
     return nothing
 end
+
 
 """
 $docstring_ymd_hms


### PR DESCRIPTION
- adds support for Spanish, Portuguese, French months and month abbreviations
- adds `hm()` 
- Bugfix: `floor_date` will not floor a date already on a Sunday 
- Bugfix: `ymd_hm`, `dmy_hm`, `mdy_hm` if minute = 60 returns `missing` with a warning instead of erroring, if hour = 24, it will add one Day to the date and drop the hour to 00.  