### PR TITLE
feat: floor_date and round_date now supports `quarter` as a unit

### DIFF
--- a/src/TidierDates.jl
+++ b/src/TidierDates.jl
@@ -67,6 +67,8 @@ function floor_date(dt::Union{DateTime, Date, Time, Missing}, unit::String)
 
     if unit == "year"
         return floor(dt, Year)
+    elseif unit == "quarter"
+        return floor(dt, Quarter)
     elseif unit == "month"
         return floor(dt, Month)
     elseif unit == "week"
@@ -84,7 +86,7 @@ function floor_date(dt::Union{DateTime, Date, Time, Missing}, unit::String)
     elseif unit == "minute"
         return floor(dt, Minute)
     else
-        throw(ArgumentError("Unit must be one of 'year', 'month', 'week', 'day', 'hour', or 'minute'."))
+        throw(ArgumentError("Unit must be one of 'year', 'quarter', 'month', 'week', 'day', 'hour', or 'minute'."))
     end
 end
 
@@ -100,6 +102,8 @@ function round_date(dt::Union{DateTime, Date, Time, Missing}, unit::String)
     if dt isa DateTime || dt isa Date
         if unit == "year"
             return round(dt, Year)
+        elseif unit == "quarter"
+            return round(dt, Quarter)
         elseif unit == "month"
             return round(dt, Month)
         elseif unit == "day"
@@ -112,7 +116,7 @@ function round_date(dt::Union{DateTime, Date, Time, Missing}, unit::String)
             elseif unit == "second"
                 return round(dt, Second)
             else
-                throw(ArgumentError("Unit must be one of 'year', 'month', 'day', 'hour', 'minute', 'second'."))
+                throw(ArgumentError("Unit must be one of 'year', 'quarter', 'month', 'day', 'hour', 'minute', 'second'."))
             end
         else
             throw(ArgumentError("Unit must be one of 'year', 'month', 'day'."))

--- a/src/datedocstrings.jl
+++ b/src/datedocstrings.jl
@@ -173,7 +173,7 @@ Round a DateTime, Date, or Time object to the nearest specified unit.
 
 # Arguments
 `dt`: A DateTime, Date, or Time object (can contain missing values in a DataFrame).
-`unit`: A string specifying the units to use for rounding. The units can be one of the following: "year", "month", "day", "hour", "minute", "second".
+`unit`: A string specifying the units to use for rounding. The units can be one of the following: "year", "quarter", "month", "day", "hour", "minute", "second".
 
 # Returns
 The DateTime, Date, or Time object rounded to the nearest specified unit. If the input is missing, the function returns a missing value.

--- a/src/datedocstrings.jl
+++ b/src/datedocstrings.jl
@@ -136,7 +136,7 @@ Round down a DateTime object to the nearest specified unit.
 
 # Arguments
 `dt`: A DateTime object (can contain missing values in a DataFrame).
-`unit`: A string specifying the units to use for rounding down. The units can be one of the following: "year", "month", "week", "day", "hour", "minute".
+`unit`: A string specifying the units to use for rounding down. The units can be one of the following: "year", "quarter", "month", "week", "day", "hour", "minute".
 
 # Returns
 The DateTime object rounded down to the nearest specified unit. If the input is missing, the function returns a missing value.
@@ -156,6 +156,9 @@ julia> floor_date(dt, "day")
 
 julia> floor_date(dt, "week")
 2023-06-11T00:00:00
+
+julia> floor_date(dt, "quarter")
+2023-04-01T00:00:00
 
 julia> floor_date(missing, "day")
 missing
@@ -185,6 +188,9 @@ julia> round_date(dt, "hour")
 
 julia> round_date(dt, "day")
 2023-06-15T00:00:00
+
+julia> round_date(dt, "quarter")
+2023-07-01T00:00:00
 
 julia> round_date(missing, "day")
 missing


### PR DESCRIPTION
This allows us to use "quarter" as a unit for 

- `floor_date`
- `round_date`

functions.