### PR TITLE
use dates.jl for 10x+ benchmark for `mdy`, `dmy`, `ymd` and `_hms` versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDates"
 uuid = "20186a3f-b5d3-468e-823e-77aae96fe2d8"
 authors = ["Daniel Rizk & Contributors"]
-version = "0.3.0"
+version = "0.3.1"
 
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDates"
 uuid = "20186a3f-b5d3-468e-823e-77aae96fe2d8"
 authors = ["Daniel Rizk & Contributors"]
-version = "0.3.1"
+version = "0.4.0"
 
 
 [deps]

--- a/src/datedocstrings.jl
+++ b/src/datedocstrings.jl
@@ -66,13 +66,6 @@ julia> dmy("3rd of December, 2020")
 
 julia> dmy(missing)
 missing
-
-julia> dmy("20 DICIEMBRE 2020") # Spanish
-2020-12-20
-
-julia> dmy("21 MARÇO 2014") # Portuguese 
-2014-03-21
-
 ```
 """
 
@@ -627,4 +620,50 @@ julia> hm("09:30")
 julia> hm("12:60")
 missing
 ```
+"""
+
+
+"""
+    set_lang(lang_str::AbstractString)
+
+Set the global language configuration for date parsing and formatting based on a language name.
+
+This function updates the global variables `full_month`, `abbrev_months`, `days_of_week`, and `lang`
+to match the specified language. It also updates the corresponding locale in `Dates.LOCALES`.
+Default supported languages are `"english"`, `"spanish"`, `"french"`, and `"portuguese"`.
+
+# Arguments
+- `lang_str::AbstractString`: The language identifier as a string (e.g., `"english"`, `"spanish"`, etc.).
+
+# Examples
+```jldoctest
+julia> set_lang("french");
+
+julia> dmy("20 janvier 2020")
+2020-01-20
+
+julia> set_lang("spanish")
+
+julia> dmy("20 diciembre 2020")
+2020-12-20
+
+julia> set_lang("portuguese")
+
+julia> dmy("21 MARÇO 2014") # Portuguese 
+2014-03-21
+```
+"""
+
+"""
+     set_lang(language::String, full_months::AbstractVector{<:AbstractString}, abbrev_months::AbstractVector{<:AbstractString}, days::AbstractVector{<:AbstractString})
+
+Set a custom language configuration for date parsing and formatting by directly providing arrays of names.
+
+This method updates the locale for the given language key in Dates.LOCALES using the specified arrays of full month names, abbreviated month names, and day names.
+
+Arguments
+- `language`: A string of the language name.
+- `full_months`::AbstractVector{<:AbstractString}`: An array of strings containing the full month names.
+- `abbrev_months::AbstractVector{<:AbstractString}`: An array containing the abbreviated month names.
+- `days::AbstractVector{<:AbstractString}`: An array containing the day names.
 """

--- a/src/dmys.jl
+++ b/src/dmys.jl
@@ -13,14 +13,14 @@ function dmy(dates_mdy)
             format = "dd-mm-yyyy"
         elseif occursin(r"^\d{2}/\d{2}/\d{4}$", date_string)
             format = "dd/mm/yyyy"
-        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
-            format = "dd u yyyy"
         elseif any(occursin(month, uppercase(date_string)) for month in full_month)
             format = "dd U yyyy"
+        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
+            format = "dd u yyyy"
         end
     end
     try
-        return Date.(dates_mdy, format)
+        return Date.(dates_mdy, format, locale=lang)
     catch
         return dmy2.(dates_mdy)
     end

--- a/src/dmys.jl
+++ b/src/dmys.jl
@@ -2,7 +2,6 @@
 $docstring_dmy
 """
 function dmy(dates_mdy)
-   # println("here")
     if isa(dates_mdy, AbstractVector)
         date_string = dates_mdy[1]
     else
@@ -23,7 +22,6 @@ function dmy(dates_mdy)
     try
         return Date.(dates_mdy, format)
     catch
-     #   println("hereeeee")
         return dmy2.(dates_mdy)
     end
 end

--- a/src/dmys.jl
+++ b/src/dmys.jl
@@ -1,7 +1,34 @@
 """
 $docstring_dmy
 """
-function dmy(date_string::Union{AbstractString, Missing})
+function dmy(dates_mdy)
+   # println("here")
+    if isa(dates_mdy, AbstractVector)
+        date_string = dates_mdy[1]
+    else
+        date_string = dates_mdy
+    end
+    format = ""
+    if !ismissing(date_string)
+        if occursin(r"^\d{2}[-/]\d{2}[-/]\d{4}$", date_string)
+            format = "dd-mm-yyyy"
+        elseif occursin(r"^\d{2}/\d{2}/\d{4}$", date_string)
+            format = "dd/mm/yyyy"
+        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
+            format = "dd u yyyy"
+        elseif any(occursin(month, uppercase(date_string)) for month in full_month)
+            format = "dd U yyyy"
+        end
+    end
+    try
+        return Date.(dates_mdy, format)
+    catch
+     #   println("hereeeee")
+        return dmy2.(dates_mdy)
+    end
+end
+
+function dmy2(date_string::Union{AbstractString, Missing})
     if ismissing(date_string)
         return missing
     else
@@ -76,6 +103,80 @@ function dmy(date_string::Union{AbstractString, Missing})
 
     return missing
 end
+
+"""
+$docstring_dmy_hms
+"""
+function dmy_hms(dates_mdy)
+    # Check if the input is a vector and take the first element
+    if isa(dates_mdy, AbstractVector)
+        date_string = dates_mdy[1]
+    else
+        date_string = dates_mdy
+    end
+    format = ""
+    if !ismissing(date_string)
+        if occursin(r"^\d{1,2}\s[a-z]{2,4}\s\d{4}\s\d{2}:\d{2}:\d{2}\s[a-z]{1,2}$", date_string)
+            format = "dd u yyyy HH:MM:SS p"
+        elseif endswith(date_string, r"[AaPp][Mm]")
+            if occursin("-", date_string)
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                    format = "dd-mm-yyyy HH:MM:SS p"
+                else
+                    format = "dd-mm-yyyy HH:MM:SSp"
+                end
+            else
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                    format = "dd/mm/yyyy HH:MM:SS p"
+                else
+                    format = "dd/mm/yyyy HH:MM:SSp"
+                end
+            end
+        else
+            if occursin("-", date_string)
+                format = "dd-mm-yyyy HH:MM:SS"
+            else
+                format = "dd/mm/yyyy HH:MM:SS"
+            end
+        end
+    end
+    try
+        return DateTime.(dates_mdy, format)
+    catch
+        return dmy_hms2.(dates_mdy)
+    end
+end
+
+function dmy_hms2(datetime_string::Union{AbstractString, Missing})
+    if ismissing(datetime_string)
+        return missing
+    else
+        datetime_string = uppercase(datetime_string)
+        datetime_string = replace_month_with_number(datetime_string)
+    end
+
+    m = match(r"(\d{1,2}).*?(\d{1,2}).*?(\d{4}).*?(\d{1,2}).*?(\d{1,2}).*?(\d{1,2})", datetime_string)
+    if m !== nothing
+        day_str, month_str, year_str, hour_str, minute_str, second_str = m.captures
+        day = parse(Int, day_str)
+        month = parse(Int, month_str)
+        year = parse(Int, year_str)
+        hour = parse(Int, hour_str)
+        if hour <= 12 && occursin(r"(?<![A-Za-z])[Pp](?:[Mm])?(?![A-Za-z])", datetime_string) 
+            hour += 12
+        end
+        minute = parse(Int, minute_str)
+        second = parse(Int, second_str)
+        # Return as DateTime
+        return DateTime(year, month, day, hour, minute, second)
+    end
+
+    # If no match found, return missing
+    return missing
+end
+
+
+
 
 """
 $docstring_dmy_h

--- a/src/dmys.jl
+++ b/src/dmys.jl
@@ -2,29 +2,29 @@
 $docstring_dmy
 """
 function dmy(dates_mdy)
-    if isa(dates_mdy, AbstractVector)
-        date_string = dates_mdy[1]
-    else
-        date_string = dates_mdy
-    end
-    format = ""
-    if !ismissing(date_string)
-        if occursin(r"^\d{2}[-/]\d{2}[-/]\d{4}$", date_string)
+    date_string = dates_mdy
+     format = ""
+     if !ismissing(date_string)
+        if occursin(r"^\d{2}[-]\d{2}[-]\d{4}$", date_string)
             format = "dd-mm-yyyy"
-        elseif occursin(r"^\d{2}/\d{2}/\d{4}$", date_string)
-            format = "dd/mm/yyyy"
-        elseif any(occursin(month, uppercase(date_string)) for month in full_month)
-            format = "dd U yyyy"
-        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
-            format = "dd u yyyy"
+        elseif occursin(r"^\d{2}[\/]\d{2}[\/]\d{4}$", date_string)
+            format = "dd/mm/yyyy"        
+         elseif any(occursin(month, uppercase(date_string)) for month in full_month)
+             format = "dd U yyyy"
+         elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
+             format = "dd u yyyy"
+         end
+     end
+     try
+        if lang == "english"
+              return Date.(dates_mdy, format)
+        else 
+            return Date.(dates_mdy, format, locale = lang)
         end
-    end
-    try
-        return Date.(dates_mdy, format, locale=lang)
-    catch
-        return dmy2.(dates_mdy)
-    end
-end
+     catch
+         return dmy2.(dates_mdy)
+     end
+ end
 
 function dmy2(date_string::Union{AbstractString, Missing})
     if ismissing(date_string)
@@ -106,25 +106,20 @@ end
 $docstring_dmy_hms
 """
 function dmy_hms(dates_mdy)
-    # Check if the input is a vector and take the first element
-    if isa(dates_mdy, AbstractVector)
-        date_string = dates_mdy[1]
-    else
-        date_string = dates_mdy
-    end
+    date_string = dates_mdy
     format = ""
     if !ismissing(date_string)
         if occursin(r"^\d{1,2}\s[a-z]{2,4}\s\d{4}\s\d{2}:\d{2}:\d{2}\s[a-z]{1,2}$", date_string)
             format = "dd u yyyy HH:MM:SS p"
-        elseif endswith(date_string, r"[AaPp][Mm]")
+        elseif occursin(r"[AaPp][Mm]$", date_string)
             if occursin("-", date_string)
-                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]$", date_string)
                     format = "dd-mm-yyyy HH:MM:SS p"
                 else
                     format = "dd-mm-yyyy HH:MM:SSp"
                 end
             else
-                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]$", date_string)
                     format = "dd/mm/yyyy HH:MM:SS p"
                 else
                     format = "dd/mm/yyyy HH:MM:SSp"
@@ -136,12 +131,20 @@ function dmy_hms(dates_mdy)
             else
                 format = "dd/mm/yyyy HH:MM:SS"
             end
-        end
+        end        
     end
-    try
-        return DateTime.(dates_mdy, format)
-    catch
-        return dmy_hms2.(dates_mdy)
+    if lang == "english"
+        try
+            return DateTime.(dates_mdy, format)
+        catch
+            return dmy_hms2.(dates_mdy)
+        end
+    else
+        try
+            return DateTime.(dates_mdy, format, locale = lang)
+        catch
+            return dmy_hms2.(dates_mdy)
+        end
     end
 end
 

--- a/src/mdys.jl
+++ b/src/mdys.jl
@@ -13,10 +13,10 @@ function mdy(dates_mdy)
             format = "mm-dd-yyyy"
         elseif occursin(r"^\d{2}/\d{2}/\d{4}$", date_string)
             format = "mm/dd/yyyy"
-        elseif any(occursin(month, uppercase.(date_string)) for month in abbrev_months)
-            format = "u dd yyyy"
-        elseif any(occursin(month, uppercase(date_string)) for month in full_month)
+        elseif any(occursin(month, uppercase.(date_string)) for month in full_month)
             format = "U dd yyyy"
+        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
+            format = "u dd yyyy"
         else
             format = "mm/dd/yyyy"
         end
@@ -135,7 +135,7 @@ function mdy_hms(dates_mdy)
         end
     end
     try
-        return DateTime.(dates_mdy, format)
+        return DateTime.(dates_mdy, format, locale = lang)
     catch
         return mdy_hms2.(dates_mdy)
     end

--- a/src/mdys.jl
+++ b/src/mdys.jl
@@ -1,7 +1,35 @@
 """
 $docstring_mdy
 """
-function mdy(date_string::Union{AbstractString, Missing})
+function mdy(dates_mdy)
+    # println("here")
+     if isa(dates_mdy, AbstractVector)
+         date_string = dates_mdy[1]
+     else
+         date_string = dates_mdy
+     end
+     format = ""
+     if !ismissing(date_string)
+        if occursin(r"^\d{2}-\d{2}-\d{4}$", date_string)
+            format = "mm-dd-yyyy"
+        elseif occursin(r"^\d{2}/\d{2}/\d{4}$", date_string)
+            format = "mm/dd/yyyy"
+        elseif any(occursin(month, uppercase.(date_string)) for month in abbrev_months)
+            format = "u dd yyyy"
+        elseif any(occursin(month, uppercase(date_string)) for month in full_month)
+            format = "U dd yyyy"
+        else
+            format = "mm/dd/yyyy"
+        end
+    end
+     try
+         return Date.(dates_mdy, format)
+     catch
+         return mdy2.(dates_mdy)
+     end
+ end
+
+function mdy2(date_string::Union{AbstractString, Missing})
 
     if ismissing(date_string)
         return missing
@@ -74,7 +102,47 @@ end
 """
 $docstring_mdy_hms
 """
-function mdy_hms(datetime_string::Union{AbstractString, Missing})
+function mdy_hms(dates_mdy)
+    # Check if the input is a vector and take the first element
+    if isa(dates_mdy, AbstractVector)
+        date_string = dates_mdy[1]
+    else
+        date_string = dates_mdy
+    end
+    format = ""
+    if !ismissing(date_string)
+        if occursin(r"^[a-z]{3,4}\s\d{1,2}\s\d{4}\s\d{2}:\d{2}:\d{2}\s[a-z]{1,2}$", date_string)
+            format = "u dd yyyy HH:MM:SS p"
+        elseif endswith(date_string, r"[AaPp][Mm]")
+            if occursin("-", date_string)
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                    format = "mm-dd-yyyy HH:MM:SS p"
+                else
+                    format = "mm-dd-yyyy HH:MM:SSp"
+                end
+            else
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                    format = "mm/dd/yyyy HH:MM:SS p"
+                else
+                    format = "mm/dd/yyyy HH:MM:SSp"
+                end
+            end
+        else
+            if occursin("-", date_string)
+                format = "mm-dd-yyyy HH:MM:SS"
+            else
+                format = "mm/dd/yyyy HH:MM:SS"
+            end
+        end
+    end
+    try
+        return DateTime.(dates_mdy, format)
+    catch
+        return mdy_hms2.(dates_mdy)
+    end
+end
+
+function mdy_hms2(datetime_string::Union{AbstractString, Missing})
 
     if ismissing(datetime_string)
         return missing

--- a/src/mdys.jl
+++ b/src/mdys.jl
@@ -2,16 +2,12 @@
 $docstring_mdy
 """
 function mdy(dates_mdy)
-     if isa(dates_mdy, AbstractVector)
-         date_string = dates_mdy[1]
-     else
-         date_string = dates_mdy
-     end
+    date_string = dates_mdy
      format = ""
      if !ismissing(date_string)
-        if occursin(r"^\d{2}-\d{2}-\d{4}$", date_string)
+        if occursin(r"^\d{2}[-]\d{2}[-]\d{4}$", date_string)
             format = "mm-dd-yyyy"
-        elseif occursin(r"^\d{2}/\d{2}/\d{4}$", date_string)
+        elseif occursin(r"^\d{2}[\/]\d{2}[\/]\d{4}$", date_string)
             format = "mm/dd/yyyy"
         elseif any(occursin(month, uppercase.(date_string)) for month in full_month)
             format = "U dd yyyy"
@@ -21,11 +17,19 @@ function mdy(dates_mdy)
             format = "mm/dd/yyyy"
         end
     end
-     try
-         return Date.(dates_mdy, format)
-     catch
-         return mdy2.(dates_mdy)
-     end
+    if lang == "english"
+        try
+            return Date.(dates_mdy, format)
+        catch
+            return mdy2.(dates_mdy)
+        end
+    else
+        try
+            return Date.(dates_mdy, format, locale = lang)
+        catch
+            return mdy2.(dates_mdy)
+        end
+    end
  end
 
 function mdy2(date_string::Union{AbstractString, Missing})
@@ -103,11 +107,7 @@ $docstring_mdy_hms
 """
 function mdy_hms(dates_mdy)
     # Check if the input is a vector and take the first element
-    if isa(dates_mdy, AbstractVector)
-        date_string = dates_mdy[1]
-    else
-        date_string = dates_mdy
-    end
+    date_string = dates_mdy
     format = ""
     if !ismissing(date_string)
         if occursin(r"^[a-z]{3,4}\s\d{1,2}\s\d{4}\s\d{2}:\d{2}:\d{2}\s[a-z]{1,2}$", date_string)
@@ -134,10 +134,18 @@ function mdy_hms(dates_mdy)
             end
         end
     end
-    try
-        return DateTime.(dates_mdy, format, locale = lang)
-    catch
-        return mdy_hms2.(dates_mdy)
+    if lang == "english"
+        try
+            return DateTime.(dates_mdy, format)
+        catch
+            return mdy_hms2.(dates_mdy)
+        end
+    else
+        try
+            return DateTime.(dates_mdy, format, locale = lang)
+        catch
+            return mdy_hms2.(dates_mdy)
+        end
     end
 end
 

--- a/src/mdys.jl
+++ b/src/mdys.jl
@@ -2,7 +2,6 @@
 $docstring_mdy
 """
 function mdy(dates_mdy)
-    # println("here")
      if isa(dates_mdy, AbstractVector)
          date_string = dates_mdy[1]
      else

--- a/src/month_dicts.jl
+++ b/src/month_dicts.jl
@@ -1,4 +1,102 @@
-#### Create dictionaries to map full and abbreviated month names to numbers
+# Define your language-specific arrays (these can be defined elsewhere)
+english_months = [
+    "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", 
+    "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"
+]
+english_months_abbr = [
+    "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", 
+    "AUG", "SEP", "OCT", "NOV", "DEC"
+]
+
+spanish_months = [
+    "ENERO", "FEBRERO", "MARZO", "ABRIL", "MAYO", "JUNIO", "JULIO",
+    "AGOSTO", "SEPTIEMBRE", "OCTUBRE", "NOVIEMBRE", "DICIEMBRE"
+]
+spanish_months_abbr = [
+    "ENE", "FEB", "MAR", "ABR", "MAY", "JUN", "JUL",
+    "AGO", "SEP", "OCT", "NOV", "DIC"
+]
+days_of_week_spanish = ["LUNES", "MARTES", "MIÉRCOLES", "JUEVES", "VIERNES", "SÁBADO", "DOMINGO"]
+
+french_months = [
+    "JANVIER", "FEVRIER", "FÉVRIER", "MARS", "AVRIL", "MAI", "JUIN", 
+    "JUILLET", "AOÛT", "AOUT", "SEPTEMBRE", "OCTOBRE", "NOVEMBRE", 
+    "DÉCEMBRE", "DECEMBRE"
+]
+french_months_abbr = [
+    "JAN", "FÉV", "MAR", "AVR", "MAI", "JUI", "JUIL",
+    "AOÛ", "AOU", "SEP", "OCT", "NOV", "DÉC"
+]
+days_of_week_french = ["LUNDI", "MARDI", "MERCREDI", "JEUDI", "VENDREDI", "SAMEDI", "DIMANCHE"]
+
+portuguese_months = [
+    "JANEIRO", "FEVEREIRO", "MARÇO", "ABRIL", "MAIO", "JUNHO", "JULHO",
+    "AGOSTO", "SETEMBRO", "OUTUBRO", "NOVEMBRO", "DEZEMBRO"
+]
+portuguese_months_abbr = [
+    "JAN", "FEV", "MAR", "ABR", "MAI", "JUN", "JUL",
+    "AGO", "SET", "OUT", "NOV", "DEZ"
+]
+days_of_week_portuguese = [
+    "SEGUNDA-FEIRA", "TERÇA-FEIRA", "QUARTA-FEIRA", 
+    "QUINTA-FEIRA", "SEXTA-FEIRA", "SÁBADO", "DOMINGO"
+]
+english_days_of_week = ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"]
+langa = []
+# Set up globals (initially default to English)
+global full_monthg = english_months
+global abbrev_monthsg = english_months_abbr
+global days_of_weekg = english_days_of_week
+global lang = "english"
+
+function set_lang(lang_str::AbstractString)
+    global full_month, abbrev_months, days_of_week, lang
+    lang_lower = lowercase(lang_str)
+    if lang_lower == "english"
+         full_month   = english_months
+         abbrev_months = english_months_abbr
+         days_of_week =  english_days_of_week
+         Dates.LOCALES["english"] = Dates.DateLocale(english_months, english_months, english_months_abbr, [""])
+         lang = lang_lower
+    elseif lang_lower == "spanish"
+         full_month   = spanish_months
+         abbrev_months = spanish_months_abbr
+         days_of_week = days_of_week_spanish
+         Dates.LOCALES["spanish"] = Dates.DateLocale(spanish_months, spanish_months, spanish_months_abbr, [""])
+         lang = lang_lower
+    elseif lang_lower == "french"
+         full_month   = french_months
+         abbrev_months = french_months_abbr
+         days_of_week = days_of_week_french
+         Dates.LOCALES["french"] = Dates.DateLocale(french_months, french_months, french_months_abbr, [""])
+         lang = lang_lower
+    elseif lang_lower == "portuguese"
+         full_month   = portuguese_months
+         abbrev_months = portuguese_months_abbr
+         days_of_week = days_of_week_portuguese
+         Dates.LOCALES["portuguese"] = Dates.DateLocale(portuguese_months, portuguese_months, portuguese_months_abbr, [""])
+         lang = lang_lower
+    else
+         error("Language '$lang_str' not supported")
+    end
+    return nothing
+end
+
+function set_lang(language, full_months_arr::AbstractVector{<:AbstractString}, 
+                  abbrev_months_arr::AbstractVector{<:AbstractString}, 
+                  days_arr::AbstractVector{<:AbstractString})
+    global full_month, abbrev_months, days_of_week, lang
+    Dates.LOCALES[language] = Dates.DateLocale(full_months_arr, abbrev_months_arr, days_arr, [""])
+    full_month   = full_months_arr
+    abbrev_months = abbrev_months_arr
+    days_of_week = days_arr
+    lang = language
+    return nothing
+end
+export set_lang
+
+
+#### For fall back functions
 full_month_to_num = Dict{String, Int}(
     "JANUARY" => 1, "FEBUARY" => 2, "MARCH" => 3, "APRIL" => 4,
     "MAY" => 5, "JUNE" => 6, "JULY" => 7, "AUGUST" => 8,
@@ -54,50 +152,6 @@ abbrev_months = [
     "AGO", "SEP", "OCT", "NOV", "DIC",
     "JAN", "FÉV", "MAR", "AVR", "MAI", "JUI", "JUIL",
     "AOÛ", "AOU", "SEP", "OCT", "NOV", "DÉC",
-    "JAN", "FEV", "MAR", "ABR", "MAI", "JUN", "JUL",
-    "AGO", "SET", "OUT", "NOV", "DEZ"
-]
-
-
-# Arrays of month names in different languages
-english_months = [
-    "JANUARY", "FEBUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", 
-    "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"
-]
-
-spanish_months = [
-    "ENERO", "FEBRERO", "MARZO", "ABRIL", "MAYO", "JUNIO", "JULIO",
-    "AGOSTO", "SEPTIEMBRE", "OCTUBRE", "NOVIEMBRE", "DICIEMBRE"
-]
-
-french_months = [
-    "JANVIER", "FEVRIER", "FÉVRIER", "MARS", "AVRIL", "MAI", "JUIN", 
-    "JUILLET", "AOÛT", "AOUT", "SEPTEMBRE", "OCTOBRE", "NOVEMBRE", 
-    "DÉCEMBRE", "DECEMBRE"
-]
-
-portuguese_months = [
-    "JANEIRO", "FEVEREIRO", "MARÇO", "ABRIL", "MAIO", "JUNHO", "JULHO",
-    "AGOSTO", "SETEMBRO", "OUTUBRO", "NOVEMBRO", "DEZEMBRO"
-]
-
-# Arrays for abbreviated month names
-english_months_abbr = [
-    "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", 
-    "AUG", "SEP", "OCT", "NOV", "DEC"
-]
-
-spanish_months_abbr = [
-    "ENE", "FEB", "MAR", "ABR", "MAY", "JUN", "JUL",
-    "AGO", "SEP", "OCT", "NOV", "DIC"
-]
-
-french_months_abbr = [
-    "JAN", "FÉV", "MAR", "AVR", "MAI", "JUI", "JUIL",
-    "AOÛ", "AOU", "SEP", "OCT", "NOV", "DÉC"
-]
-
-portuguese_months_abbr = [
     "JAN", "FEV", "MAR", "ABR", "MAI", "JUN", "JUL",
     "AGO", "SET", "OUT", "NOV", "DEZ"
 ]

--- a/src/month_dicts.jl
+++ b/src/month_dicts.jl
@@ -32,3 +32,73 @@ abbreviated_month_to_num = Dict{String, Int}(
     "SEP" => 9, "OCT" => 10, "NOV" => 11, "DÉC" => 12,
     #portugues
 )
+
+# All full month names across languages
+full_month = [
+    "JANUARY", "FEBUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", 
+    "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER",
+    "ENERO", "FEBRERO", "MARZO", "ABRIL", "MAYO", "JUNIO", "JULIO",
+    "AGOSTO", "SEPTIEMBRE", "OCTUBRE", "NOVIEMBRE", "DICIEMBRE",
+    "JANVIER", "FEVRIER", "FÉVRIER", "MARS", "AVRIL", "MAI", "JUIN", 
+    "JUILLET", "AOÛT", "AOUT", "SEPTEMBRE", "OCTOBRE", "NOVEMBRE", 
+    "DÉCEMBRE", "DECEMBRE",
+    "JANEIRO", "FEVEREIRO", "MARÇO", "ABRIL", "MAIO", "JUNHO", "JULHO",
+    "AGOSTO", "SETEMBRO", "OUTUBRO", "NOVEMBRO", "DEZEMBRO"
+]
+
+# All abbreviated month names across languages
+abbrev_months = [
+    "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", 
+    "AUG", "SEP", "OCT", "NOV", "DEC",
+    "ENE", "FEB", "MAR", "ABR", "MAY", "JUN", "JUL",
+    "AGO", "SEP", "OCT", "NOV", "DIC",
+    "JAN", "FÉV", "MAR", "AVR", "MAI", "JUI", "JUIL",
+    "AOÛ", "AOU", "SEP", "OCT", "NOV", "DÉC",
+    "JAN", "FEV", "MAR", "ABR", "MAI", "JUN", "JUL",
+    "AGO", "SET", "OUT", "NOV", "DEZ"
+]
+
+
+# Arrays of month names in different languages
+english_months = [
+    "JANUARY", "FEBUARY", "MARCH", "APRIL", "MAY", "JUNE", "JULY", 
+    "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"
+]
+
+spanish_months = [
+    "ENERO", "FEBRERO", "MARZO", "ABRIL", "MAYO", "JUNIO", "JULIO",
+    "AGOSTO", "SEPTIEMBRE", "OCTUBRE", "NOVIEMBRE", "DICIEMBRE"
+]
+
+french_months = [
+    "JANVIER", "FEVRIER", "FÉVRIER", "MARS", "AVRIL", "MAI", "JUIN", 
+    "JUILLET", "AOÛT", "AOUT", "SEPTEMBRE", "OCTOBRE", "NOVEMBRE", 
+    "DÉCEMBRE", "DECEMBRE"
+]
+
+portuguese_months = [
+    "JANEIRO", "FEVEREIRO", "MARÇO", "ABRIL", "MAIO", "JUNHO", "JULHO",
+    "AGOSTO", "SETEMBRO", "OUTUBRO", "NOVEMBRO", "DEZEMBRO"
+]
+
+# Arrays for abbreviated month names
+english_months_abbr = [
+    "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", 
+    "AUG", "SEP", "OCT", "NOV", "DEC"
+]
+
+spanish_months_abbr = [
+    "ENE", "FEB", "MAR", "ABR", "MAY", "JUN", "JUL",
+    "AGO", "SEP", "OCT", "NOV", "DIC"
+]
+
+french_months_abbr = [
+    "JAN", "FÉV", "MAR", "AVR", "MAI", "JUI", "JUIL",
+    "AOÛ", "AOU", "SEP", "OCT", "NOV", "DÉC"
+]
+
+portuguese_months_abbr = [
+    "JAN", "FEV", "MAR", "ABR", "MAI", "JUN", "JUL",
+    "AGO", "SET", "OUT", "NOV", "DEZ"
+]
+

--- a/src/time_wraps.jl
+++ b/src/time_wraps.jl
@@ -1,0 +1,23 @@
+function hour(time)
+    return ismissing(time) ? missing : Dates.hour(time)
+end
+
+function minute(time)
+    return ismissing(time) ? missing : Dates.minute(time)
+end
+
+function second(time)
+    return ismissing(time) ? missing : Dates.second(time)
+end
+
+function day(time)
+    return ismissing(time) ? missing : Dates.day(time)
+end
+
+function month(time)
+    return ismissing(time) ? missing : Dates.month(time)
+end
+
+function year(time)
+    return ismissing(time) ? missing : Dates.year(time)
+end

--- a/src/ymds.jl
+++ b/src/ymds.jl
@@ -2,21 +2,17 @@
 $docstring_ymd
 """
 function ymd(dates_mdy)
-    if isa(dates_mdy, AbstractVector)
-        date_string = dates_mdy[1]
-    else
-        date_string = dates_mdy
-    end
+    date_string = dates_mdy
     format = ""
     if !ismissing(date_string)
         if occursin(r"^\d{4}-\d{2}-\d{2}$", date_string)
             format = "yyyy-mm-dd"
         elseif occursin(r"^\d{8}$", date_string)  # Check for yyyymmdd format
             format = "yyyymmdd"
-        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
-            format = "yyyy u dd"
         elseif any(occursin(month, uppercase(date_string)) for month in full_month)
             format = "yyyy U dd"
+        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
+            format = "yyyy u dd"
         else
             format = "yyyy/mm/dd"
         end

--- a/src/ymds.jl
+++ b/src/ymds.jl
@@ -7,7 +7,7 @@ function ymd(dates_mdy)
     if !ismissing(date_string)
         if occursin(r"^\d{4}-\d{2}-\d{2}$", date_string)
             format = "yyyy-mm-dd"
-        elseif occursin(r"^\d{8}$", date_string)  # Check for yyyymmdd format
+        elseif occursin(r"^\d{8}$", date_string)  
             format = "yyyymmdd"
         elseif any(occursin(month, uppercase(date_string)) for month in full_month)
             format = "yyyy U dd"
@@ -17,10 +17,18 @@ function ymd(dates_mdy)
             format = "yyyy/mm/dd"
         end
     end
-    try
-        return Date.(dates_mdy, format)
-    catch
-        return ymd2.(dates_mdy)
+    if lang == "english"
+        try
+            return Date.(dates_mdy, format)
+        catch
+            return ymd2.(dates_mdy)
+        end
+    else
+        try
+            return Date.(dates_mdy, format, locale = lang)
+        catch
+            return ymd2.(dates_mdy)
+        end
     end
 end
 
@@ -114,12 +122,7 @@ end
 $docstring_ymd_hms
 """
 function ymd_hms(dates_mdy)
-    # Check if the input is a vector and take the first element
-    if isa(dates_mdy, AbstractVector)
-        date_string = dates_mdy[1]
-    else
-        date_string = dates_mdy
-    end
+    date_string = dates_mdy
     format = ""
     if !ismissing(date_string)
         if endswith(date_string, r"[AaPp][Mm]")
@@ -144,10 +147,18 @@ function ymd_hms(dates_mdy)
             end
         end
     end
-    try
-        return DateTime.(dates_mdy, format)
-    catch
-        return ymd_hms2.(dates_mdy)
+    if lang == "english"
+        try
+            return DateTime.(dates_mdy, format)
+        catch
+            return ymd_hms2.(dates_mdy)
+        end
+    else
+        try
+            return DateTime.(dates_mdy, format, locale = lang)
+        catch
+            return ymd_hms2.(dates_mdy)
+        end
     end
 end
 

--- a/src/ymds.jl
+++ b/src/ymds.jl
@@ -1,7 +1,34 @@
 """
 $docstring_ymd
 """
-function ymd(date_string::Union{AbstractString, Missing})
+function ymd(dates_mdy)
+    if isa(dates_mdy, AbstractVector)
+        date_string = dates_mdy[1]
+    else
+        date_string = dates_mdy
+    end
+    format = ""
+    if !ismissing(date_string)
+        if occursin(r"^\d{4}-\d{2}-\d{2}$", date_string)
+            format = "yyyy-mm-dd"
+        elseif occursin(r"^\d{8}$", date_string)  # Check for yyyymmdd format
+            format = "yyyymmdd"
+        elseif any(occursin(month, uppercase(date_string)) for month in abbrev_months)
+            format = "yyyy u dd"
+        elseif any(occursin(month, uppercase(date_string)) for month in full_month)
+            format = "yyyy U dd"
+        else
+            format = "yyyy/mm/dd"
+        end
+    end
+    try
+        return Date.(dates_mdy, format)
+    catch
+        return ymd2.(dates_mdy)
+    end
+end
+
+function ymd2(date_string::Union{AbstractString, Missing})
 
     if ismissing(date_string)
         return missing
@@ -90,7 +117,45 @@ end
 """
 $docstring_ymd_hms
 """
-function ymd_hms(datetime_string::Union{AbstractString, Missing})
+function ymd_hms(dates_mdy)
+    # Check if the input is a vector and take the first element
+    if isa(dates_mdy, AbstractVector)
+        date_string = dates_mdy[1]
+    else
+        date_string = dates_mdy
+    end
+    format = ""
+    if !ismissing(date_string)
+        if endswith(date_string, r"[AaPp][Mm]")
+            if occursin("-", date_string)
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                    format = "yyyy-mm-dd HH:MM:SS p"
+                else
+                    format = "yyyy-mm-dd HH:MM:SSp"
+                end
+            else
+                if occursin(r"\d{2}:\d{2}:\d{2} [AaPp][Mm]", date_string)
+                    format = "yyyy/mm/dd HH:MM:SS p"
+                else
+                    format = "yyyy/mm/dd HH:MM:SSp"
+                end
+            end
+        else
+            if occursin("-", date_string)
+                format = "yyyy-mm-dd HH:MM:SS"
+            else
+                format = "yyyy/mm/dd HH:MM:SS"
+            end
+        end
+    end
+    try
+        return DateTime.(dates_mdy, format)
+    catch
+        return ymd_hms2.(dates_mdy)
+    end
+end
+
+function ymd_hms2(datetime_string::Union{AbstractString, Missing})
     # If input is missing, return missing
     if ismissing(datetime_string)
         return missing


### PR DESCRIPTION
improve initial parsing to better leverage Dates.jl and bring benchmarks nearly inline w dates.jl, without sacrificing flexibility for 
- `mdy_hms`, `mdy`
- `ymd_hms`, `ymd`
- `dmy_hms`, `dmy`


 for ex 
 
```
@benchmark @mutate(dates, test = Date(dt2, "dd-mm-yyyy"))
BenchmarkTools.Trial: 1398 samples with 1 evaluation per sample.
 Range (min … max):  2.927 ms … 258.430 ms  ┊ GC (min … max): 0.00% … 98.37%
 Time  (median):     3.219 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.573 ms ±   6.860 ms  ┊ GC (mean ± σ):  8.23% ±  9.48%

   █▆▄▂                                                        
  █████▆▅█▅▆▃▂▂▂▂▂▂▂▂▂▂▁▂▁▁▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▂ ▃
  2.93 ms         Histogram: frequency by time         7.6 ms <

 Memory estimate: 1.42 MiB, allocs estimate: 25145.

@benchmark @mutate(dates, test = dmy(dt2))
BenchmarkTools.Trial: 1287 samples with 1 evaluation per sample.
 Range (min … max):  3.163 ms … 250.221 ms  ┊ GC (min … max): 0.00% … 98.13%
 Time  (median):     3.365 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.882 ms ±   6.947 ms  ┊ GC (mean ± σ):  7.76% ±  9.09%

  ▅█▆▅▅▃▂▂▃▂▁                                                  
  ███████████▇▇▆▆▇▅▇▆▆▆▅▆▄▁▄▅▅▁▄▄▄▁▁▁▁▄▁▄▄▁▄▄▄▁▄▄▆▅▅▇▅▄▆▄▄▄▁▅ █
  3.16 ms      Histogram: log(frequency) by time      8.15 ms <

 Memory estimate: 1.44 MiB, allocs estimate: 26145.
```